### PR TITLE
Flag to lift the pivot bar by a bit

### DIFF
--- a/app/2015YTm.css
+++ b/app/2015YTm.css
@@ -5908,3 +5908,10 @@ html.style-2013.dark.dark-21 {
 .style-2013.dark.dark-21 .ytm15-video-owner .material-button-container[data-style="BRAND"] .material-button {
     background: linear-gradient(#323232, #252525);
 }
+.lift-pivot .pivot-bar-item-tab {
+    bottom: 10px;
+}
+
+.lift-pivot ytm15-pivot-bar {
+    height: 72px;
+}

--- a/app/2015YTm.css
+++ b/app/2015YTm.css
@@ -5908,3 +5908,11 @@ html.style-2013.dark.dark-21 {
 .style-2013.dark.dark-21 .ytm15-video-owner .material-button-container[data-style="BRAND"] .material-button {
     background: linear-gradient(#323232, #252525);
 }
+
+.lift-pivot .pivot-bar-item-tab {
+    bottom: 10px;
+}
+
+.lift-pivot ytm15-pivot-bar {
+    height: 72px;
+}

--- a/app/2015ytm.js
+++ b/app/2015ytm.js
@@ -140,6 +140,7 @@ DISABLE_TAB_ICONS_expflag = localStorage.getItem("DISABLE_TAB_ICONS");
 WATCH_ENABLE_NEW_UI_expflag = localStorage.getItem("WATCH_ENABLE_NEW_UI");
 WATCH_TILTE_FONT_WEIGHT_500_expflag = localStorage.getItem("WATCH_TILTE_FONT_WEIGHT_500");
 USE_NEW_SUBSCRIBE_ICON_expflag = localStorage.getItem("USE_NEW_SUBSCRIBE_ICON");
+LIFT_PIVOT_BAR_FOR_PHONE_expflag = localStorage.getItem("LIFT_PIVOT_BAR_FOR_PHONE");
 
 if (DISABLE_YTM15_APP_BORDER_expflag == "true") {
     documentHTML.classList.add("no-app-border");
@@ -215,6 +216,12 @@ if (APP_DEMATERIALIZE_UI_expflag == "true") {
     documentHTML.classList.add("style-2013");
 } else {
     documentHTML.classList.remove("style-2013");
+}
+
+if (LIFT_PIVOT_BAR_FOR_PHONE_expflag == "true") {
+  documentHTML.classList.add("lift-pivot");
+} else {
+  documentHTML.classList.remove("lift-pivot");
 }
 };
 

--- a/app/settings.js
+++ b/app/settings.js
@@ -511,6 +511,15 @@ function settingsPage() {
         "pressed-default": false,
         "disabled": false,
         "lsitem": "USE_NEW_SUBSCRIBE_ICON"
+      },
+      {
+        "type": "boolean",
+        "title": "LIFT_PIVOT_BAR_FOR_PHONE",
+        "subtitle": "",
+        "pressed": LIFT_PIVOT_BAR_FOR_PHONE_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "LIFT_PIVOT_BAR_FOR_PHONE"
       }
       ];
       settingBlocks.forEach(function(item){


### PR DESCRIPTION
I submitted this PR to the original repo but it looks like it's dead so i'm putting it here
also can you enable issues? Go to your settings and check that
![image](https://github.com/user-attachments/assets/c0f747ce-81f6-4248-a961-c9dee0678cc2)





On an iphone, the little notch/bar/line at the bottom appears over the pivot bar, this will add a flag  (`app/2015ytm.js`, [app/2015ytm.jsR143](diffhunk://#diff-5c21f8d77051bf0e8436a365db87983233239575a49ec0e7cbcaa9ea91e87c1dR143)) that will move it up by a bit so it won't get in the way

Before:
![IMG_5528](https://github.com/user-attachments/assets/a86c10f2-ccd4-4b73-90b7-c706835a8fdc)

After (there's no top bar cuz i screenshotted it on firefox):
![IMG_5534](https://github.com/user-attachments/assets/7e8c7aa6-0363-4310-9367-f9ab6bd9f981)